### PR TITLE
fix: stop parsing numbers from text like where preceding characters are alphanumeric

### DIFF
--- a/src/utilities/inspect.spec.ts
+++ b/src/utilities/inspect.spec.ts
@@ -107,6 +107,12 @@ test('inspect preserves non-parseable strings', (t) => {
   t.is(result.sample[0].name, 'Coffee Shop');
 });
 
+test('inspect preserves text with embedded digits', (t) => {
+  const csv = 'description\nCAFE*TH3 BREWHOUSE';
+  const result = inspect(csv, { attemptParsing: true });
+  t.is(result.sample[0].description, 'CAFE*TH3 BREWHOUSE');
+});
+
 // Edge cases
 test('inspect handles whitespace in CSV', (t) => {
   const csv = '  date,amount\n  2024-01-01,100  ';

--- a/src/utilities/parse.spec.ts
+++ b/src/utilities/parse.spec.ts
@@ -131,6 +131,12 @@ test('tryParseNumber handles whitespace', (t) => {
   t.is(tryParseNumber('  100  '), 100);
 });
 
+test('tryParseNumber returns null for text with embedded digits', (t) => {
+  t.is(tryParseNumber('CAFE*TH3 BREWHOUSE'), null);
+  t.is(tryParseNumber('A1 STEAK SAUCE'), null);
+  t.is(tryParseNumber('Room 101'), null);
+});
+
 // parseMetadata tests
 test('parseMetadata parses valid JSON string', (t) => {
   t.deepEqual(parseMetadata('{"key": "value"}'), { key: 'value' });

--- a/src/utilities/parse.ts
+++ b/src/utilities/parse.ts
@@ -105,6 +105,11 @@ export function tryParseNumber(value: string): number | null {
     return null;
   }
 
+  const prefix = value.slice(0, match.index);
+  if (prefix.length > 0 && /[a-zA-Z]/.test(prefix)) {
+    return null;
+  }
+
   const numericPart = value.slice(match.index);
   const parsed = parseFloat(numericPart);
   if (!Number.isFinite(parsed)) {


### PR DESCRIPTION
Summary
- Fix tryParseNumber to return null when digits are embedded in text (e.g. "CAFE*TH3 BREWHOUSE")
- Adds a prefix check that rejects values where letters appear before the first numeric character
- Still allows non-letter prefixes like currency symbols 